### PR TITLE
Add VNC support for remote machine control

### DIFF
--- a/computer-use/main.py
+++ b/computer-use/main.py
@@ -8,9 +8,11 @@ import argparse
 import logging
 import os
 import openai
+import asyncio
 
 import cua
 from local_computer import LocalComputer
+from vnc_computer import VNCComputer
 
 def main():
     logging.basicConfig(level=logging.WARNING, format='%(message)s')
@@ -23,6 +25,10 @@ def main():
     parser.add_argument("--autoplay", dest="autoplay", help="Autoplay VM actions without confirmation, only pause when the turn ends", action="store_true", default=True)
     parser.add_argument("--environment", dest="environment", default="linux")
     parser.add_argument("--vm-address", dest="vm_address", help="The address of the VM to use", type=str, default=None)
+    parser.add_argument("--host", dest="host", help="VNC host address", type=str, default=None)
+    parser.add_argument("--port", dest="port", help="VNC port", type=int, default=5900)
+    parser.add_argument("--username", dest="username", help="VNC username", type=str, default=None)
+    parser.add_argument("--password", dest="password", help="VNC password", type=str, default=None)
     args = parser.parse_args()
 
     if args.endpoint == "azure":
@@ -36,7 +42,11 @@ def main():
     model = args.model
 
     # Computer is used to take screenshots and send keystrokes or mouse clicks
-    computer = LocalComputer()
+    if args.host:
+        computer = VNCComputer(args.host, args.port, args.username, args.password)
+        asyncio.run(computer.connect())
+    else:
+        computer = LocalComputer()
 
     # Scaler is used to resize the screen to a smaller size
     size = (1024, 768)

--- a/computer-use/requirements.txt
+++ b/computer-use/requirements.txt
@@ -1,3 +1,4 @@
 openai>=1.68.2
 pyautogui
 requests
+asyncvnc

--- a/computer-use/vnc_computer.py
+++ b/computer-use/vnc_computer.py
@@ -1,0 +1,58 @@
+import base64
+import io
+import time
+import asyncvnc
+
+class VNCComputer:
+    """Controls a remote computer using VNC."""
+
+    def __init__(self, host, port=5900, username=None, password=None):
+        self.host = host
+        self.port = port
+        self.username = username
+        self.password = password
+        self.client = None
+        self.dimensions = (0, 0)
+        self.environment = "unknown"
+
+    async def connect(self):
+        self.client = await asyncvnc.connect(
+            host=self.host,
+            port=self.port,
+            username=self.username,
+            password=self.password
+        )
+        self.dimensions = await self.client.get_screen_size()
+        self.environment = "remote"
+
+    async def screenshot(self) -> str:
+        screenshot = await self.client.screenshot()
+        buffer = io.BytesIO()
+        screenshot.save(buffer, format="PNG")
+        buffer.seek(0)
+        data = bytearray(buffer.getvalue())
+        return base64.b64encode(data).decode("utf-8")
+
+    async def click(self, x: int, y: int, button: str = "left") -> None:
+        await self.client.click(x, y, button=button)
+
+    async def double_click(self, x: int, y: int) -> None:
+        await self.client.double_click(x, y)
+
+    async def scroll(self, x: int, y: int, scroll_x: int, scroll_y: int) -> None:
+        await self.client.scroll(x, y, scroll_x, scroll_y)
+
+    async def type(self, text: str) -> None:
+        await self.client.type(text)
+
+    async def wait(self, ms: int = 1000) -> None:
+        time.sleep(ms / 1000)
+
+    async def move(self, x: int, y: int) -> None:
+        await self.client.move(x, y)
+
+    async def keypress(self, keys: list[str]) -> None:
+        await self.client.keypress(keys)
+
+    async def drag(self, path: list[dict[str, int]]) -> None:
+        await self.client.drag(path)


### PR DESCRIPTION
Add VNC support to control a remote machine using asyncvnc.

* **Add VNCComputer class**
  - Create `VNCComputer` class in `vnc_computer.py` to handle VNC connections and perform actions like `screenshot`, `click`, `double_click`, `scroll`, `type`, `wait`, `move`, `keypress`, and `drag`.
  - Use `asyncvnc` library for VNC connection and actions.

* **Update requirements**
  - Add `asyncvnc` to `requirements.txt`.

* **Modify main.py**
  - Add command-line arguments for VNC connection details: `host`, `port`, `username`, and `password`.
  - Modify code to use `VNCComputer` instead of `LocalComputer` when VNC arguments are provided.
  - Update `computer` initialization to handle both local and VNC connections.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JoshuaGruber/computer-use-model/pull/1?shareId=57eef5be-d3a5-4a99-a95f-3f7cb079aabb).